### PR TITLE
Fix permissions issue with /usethischannel command

### DIFF
--- a/DiscordBot/main.py
+++ b/DiscordBot/main.py
@@ -76,7 +76,7 @@ async def help(Interaction: discord.Interaction):
 #================================================================================================
 
 @client.tree.command(name="usethischannel", description="(Un)Set the current channel as the results channel. (Admin only)")
-@commands.has_permissions(administrator=True)
+@app_commands.checks.has_permissions(administrator=True)
 async def usethischannel(Interaction: discord.Interaction):
     if Interaction.guild is None:
         await Interaction.response.send_message("This command can only be used in a server.")
@@ -102,8 +102,8 @@ async def usethischannel(Interaction: discord.Interaction):
         await Interaction.response.send_message(f"An error occurred: {e}")
 
 @usethischannel.error
-async def usethischannel_error(Interaction: discord.Interaction, error: commands.CommandError):
-    if isinstance(error, commands.MissingPermissions):
+async def usethischannel_error(Interaction: discord.Interaction, error: app_commands.AppCommandError):
+    if isinstance(error, app_commands.MissingPermissions):
         await Interaction.response.send_message("You do not have the required permissions to use this command.", ephemeral=True)
     else:
         await Interaction.response.send_message("An error occurred while trying to run this command.", ephemeral=True)


### PR DESCRIPTION
# Description

In the dev branch, modifications to the bot were made to use slash commands. When these updates were made, an issue manifested which allowed non-administrators to use the /usethischannel command. This pull request addresses that issue.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] Had a user without administrator permissions use the `/usethischannel` command - they received the "You do not have the required permissions to use this command" error.
- [X] Had a user with administrator permissions (me, in this case) use the `/usethischannel` command - the command was successful and the `/usethischannel` command worked as expected.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works